### PR TITLE
Update brexiteering.ipynb

### DIFF
--- a/brexiteering.ipynb
+++ b/brexiteering.ipynb
@@ -599,7 +599,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#- Show a histogram of the `numage` column from `remainers`"
+    "#- Show a histogram of the `numage` column from `leavers`"
    ]
   },
   {
@@ -744,7 +744,7 @@
    "source": [
     "#- Logic for a single trial.\n",
     "#- One trial is n_total voters.\n",
-    "randoms = np.random.uniform...\n",
+    "random_votes = np.random.uniform...\n",
     "#- Convert to an array of n_total Boolean (True / False) values.\n",
     "leaves = ...\n",
     "#- Calculate the proportion of Trues.\n",
@@ -797,6 +797,27 @@
    "outputs": [],
    "source": [
     "plt.hist(simulated_proportions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "OPTIONAL EXTRA: trying pasting the following code in the cell above, after the code for the histogram you just plotted. Re-run the cell after you have pasted the code. 
+    It will plot the actual proportion of leavers as a red dot, so you can see how different/similar it is to the proportions we obtained in the simulation." 
+   ]
+  },
+  { "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# do not worry about this code for now. It just plots the actual proportion of leavers in the survey sample, and adds some labels to your histogram
+     fontsize = {'fontsize': 11}
+     plt.xlabel('Proportion', **fontsize)
+     plt.ylabel('Number of times obtained in simulation', **fontsize)
+     plt.plot(leave_proportion, 20, 'o', markersize = 10, color = 'red', label = 'actual proportion of leavers')
+     plt.legend(loc = 'upper left', **fontsize)"
    ]
   },
   {


### PR DESCRIPTION
# 1

In cell 36, the text above the cell says: "Do a histogram of the values in the numage column of leavers:"

But the comment in the cell says "#- Show a histogram of the `numage` column from `remainers`".


# 2
In the cell where the text before it reads 'As usual, we start with a cell to do the simulation for a single trial.'  For the code which reads:
"#- One trial is n_total voters.
randoms = np.random.uniform(0,1, size = n_total)"

It might be clearer to call that variable 'random_votes' rather than randoms


# 3

When they plot the histogram of the simulated proportions, it could be good to have the code I've added as an optional extra which they can paste and run (it might make it clearer for those who are slightly unclear on what comparison they are meant to make).